### PR TITLE
[Refactor] api 요청 custom hooks로 변경

### DIFF
--- a/src/api/todo.ts
+++ b/src/api/todo.ts
@@ -7,7 +7,7 @@ export const getTodoList = async () => {
   try {
     const response = await apiRequest.get({ url: `${RESOURCE}` });
 
-    return response;
+    return response.data;
   } catch (error) {
     throw new Error(API_ERROR_MESSAGE.GET_TODO);
   }
@@ -22,7 +22,7 @@ export const createTodo = async (title: string) => {
       },
     });
 
-    return response;
+    return response.data;
   } catch (error) {
     throw new Error(API_ERROR_MESSAGE.CREATE_TODO);
   }
@@ -32,7 +32,7 @@ export const deleteTodo = async (id: string) => {
   try {
     const response = await apiRequest.delete({ url: `${RESOURCE}/${id}` });
 
-    return response;
+    return response.data;
   } catch (error) {
     throw new Error(API_ERROR_MESSAGE.DELETE_TODO);
   }

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,30 +1,28 @@
 import { FaSpinner, FaTrash } from 'react-icons/fa';
-import React, { useCallback, useState } from 'react';
+import React from 'react';
 
-import { deleteTodo } from '../api/todo';
 import { TodoType } from '../types';
 import { ALERT_MESSAGE } from '../constants/message';
+import useDeleteTodo from '../hooks/todos/useDeleteTodo';
 
 type TodoItemProps = TodoType & {
   setTodos: React.Dispatch<React.SetStateAction<TodoType[]>>;
 };
 
 function TodoItem({ id, title, setTodos }: TodoItemProps) {
-  const [isLoading, setIsLoading] = useState(false);
-
-  const handleRemoveTodo = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      await deleteTodo(id);
-
+  const { mutate: deleteTodoMutate, isLoading } = useDeleteTodo({
+    onSuccess: () => {
       setTodos((prev) => prev.filter((item) => item.id !== id));
-    } catch (error) {
+    },
+    onError: (error) => {
       console.error(error);
       alert(ALERT_MESSAGE.ERROR);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id, setTodos]);
+    },
+  });
+
+  const handleRemoveTodo = async () => {
+    await deleteTodoMutate(id);
+  };
 
   return (
     <li className="item">

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -7,4 +7,4 @@ export const API_ERROR_MESSAGE = {
 export const ALERT_MESSAGE = {
   EMPTY: 'Please write something',
   ERROR: 'Something went wrong.',
-};
+} as const;

--- a/src/hooks/todos/useCreateTodo.ts
+++ b/src/hooks/todos/useCreateTodo.ts
@@ -1,0 +1,22 @@
+import { createTodo } from '../../api/todo';
+import { TodoType } from '../../types';
+import useMutate from '../useMutate';
+
+type UseCreateTodoProps = {
+  onSuccess?: (data: TodoType) => void;
+  onError?: (error: unknown) => void;
+  onSettled?: (data: TodoType, error: unknown) => void;
+};
+
+function useCreateTodo({ onSuccess, onError, onSettled }: UseCreateTodoProps = {}) {
+  const { mutate, isLoading } = useMutate({
+    fetchFn: createTodo,
+    onSuccess,
+    onError,
+    onSettled,
+  });
+
+  return { isLoading, mutate };
+}
+
+export default useCreateTodo;

--- a/src/hooks/todos/useDeleteTodo.ts
+++ b/src/hooks/todos/useDeleteTodo.ts
@@ -1,0 +1,22 @@
+import { deleteTodo } from '../../api/todo';
+import { TodoType } from '../../types';
+import useMutate from '../useMutate';
+
+type UseDeleteTodoProps = {
+  onSuccess?: (data: TodoType) => void;
+  onError?: (error: unknown) => void;
+  onSettled?: (data: TodoType, error: unknown) => void;
+};
+
+function useDeleteTodo({ onSuccess, onError, onSettled }: UseDeleteTodoProps = {}) {
+  const { mutate, isLoading } = useMutate({
+    fetchFn: deleteTodo,
+    onSuccess,
+    onError,
+    onSettled,
+  });
+
+  return { isLoading, mutate };
+}
+
+export default useDeleteTodo;

--- a/src/hooks/todos/useGetTodos.ts
+++ b/src/hooks/todos/useGetTodos.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { getTodoList } from '../../api/todo';
+import { TodoType } from '../../types';
+import userQuery from '../useQuery';
+
+type UseGetTodosProps = {
+  onSuccess?: (data: TodoType) => void;
+  onError?: (error: unknown) => void;
+  onSettled?: (data: TodoType, error: unknown) => void;
+};
+
+function useGetTodos({ onSuccess, onError, onSettled }: UseGetTodosProps = {}) {
+  const { data, isLoading, error } = userQuery({
+    fetchFn: getTodoList,
+    onSuccess,
+    onError,
+    onSettled,
+  });
+
+  const [todos, setTodos] = useState<TodoType[]>([]);
+
+  useEffect(() => {
+    if (data) {
+      setTodos(data);
+    }
+  }, [data]);
+
+  return { isLoading, todos, setTodos, error };
+}
+
+export default useGetTodos;

--- a/src/hooks/useMutate.ts
+++ b/src/hooks/useMutate.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+type ArgsType<T> = T extends (...args: infer U) => any ? U : never;
+type PromiseReturnType<T> = T extends (...args: any[]) => Promise<infer R> ? R : never;
+
+type UseMutateProps<T extends (...args: any[]) => Promise<any>> = {
+  fetchFn: T;
+  onSuccess?: (data: PromiseReturnType<T>) => void;
+  onError?: (error: unknown) => void;
+  onSettled?: (data: PromiseReturnType<T> | undefined, error: unknown) => void;
+};
+
+function useMutate<T extends (...args: any[]) => Promise<any>>({
+  fetchFn,
+  onSuccess,
+  onError,
+  onSettled,
+}: UseMutateProps<T>) {
+  const [data, setData] = useState<PromiseReturnType<T>>();
+  const [error, setError] = useState<unknown>();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const mutate = async (...args: ArgsType<T>) => {
+    try {
+      setIsLoading(true);
+
+      const fetchData = await fetchFn(...args);
+
+      setData(fetchData);
+      onSuccess && onSuccess(fetchData);
+    } catch (_error) {
+      setError(_error);
+      onError && onError(_error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isLoading === false) {
+      onSettled && onSettled(data, error);
+    }
+  }, [data, error, isLoading]);
+
+  return { isLoading, mutate, data, error };
+}
+
+export default useMutate;

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+type PromiseReturnType<T> = T extends (...args: any[]) => Promise<infer R> ? R : never;
+
+type UseQueryProps<T extends (...args: any[]) => any> = {
+  fetchFn: T;
+  onSuccess?: (data: PromiseReturnType<T> | undefined) => void;
+  onError?: (error: unknown) => void;
+  onSettled?: (data: PromiseReturnType<T> | undefined, error: unknown) => void;
+};
+
+function userQuery<T extends (...args: any[]) => any>({
+  fetchFn,
+  onSuccess,
+  onError,
+  onSettled,
+}: UseQueryProps<T>) {
+  const [data, setData] = useState<PromiseReturnType<T> | undefined>();
+  const [error, setError] = useState<unknown>();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const query = async () => {
+    try {
+      setIsLoading(true);
+
+      const fetchData = await fetchFn();
+
+      setData(fetchData);
+      onSuccess && onSuccess(data);
+    } catch (_error) {
+      setError(_error);
+      onError && onError(_error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isLoading === false) {
+      onSettled && onSettled(data, error);
+    }
+  }, [data, error, isLoading, onSettled]);
+
+  useEffect(() => {
+    query();
+  }, []);
+
+  return { isLoading, refetch: query, data, error };
+}
+
+export default userQuery;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,27 +1,18 @@
-import { useEffect, useState } from 'react';
-
 import Header from '../components/Header';
 import InputTodo from '../components/InputTodo';
 import TodoList from '../components/TodoList';
-import { getTodoList } from '../api/todo';
-import { TodoType } from '../types';
+import useGetTodos from '../hooks/todos/useGetTodos';
 
 function Main() {
-  const [todoListData, setTodoListData] = useState<TodoType[]>([]);
-
-  useEffect(() => {
-    (async () => {
-      const { data } = await getTodoList();
-      setTodoListData(data || []);
-    })();
-  }, []);
+  // const [todoListData, setTodoListData] = useState<TodoType[]>([]);
+  const { todos, setTodos } = useGetTodos();
 
   return (
     <div className="container">
       <div className="inner">
         <Header />
-        <InputTodo setTodos={setTodoListData} />
-        <TodoList todos={todoListData} setTodos={setTodoListData} />
+        <InputTodo setTodos={setTodos} />
+        <TodoList todos={todos} setTodos={setTodos} />
       </div>
     </div>
   );


### PR DESCRIPTION
## 이슈 번호
- #7 

## 개발 내용
- api 응답 response에서 response.data로 수정
  ```ts
  return response.data;
  ```
- userQuery 추가
- useMutate 추가
- useGetTodos 추가
  - 상태 관리를 위해 useState 추가
- useDeleteTodo 추가
- useCreateTodo 추가 

## 새로 알게된 내용
- 조건부 타입 추론 `infer` 키워드
  - infer는 반드시 조건부 타입에서만 사용이 가능합니다
    - 조건부 타입
      ```
      T extends U ? X : Y
      ```
  - 사용 예시
    ```ts
    type ArgsType<T> = T extends (...args: infer U) => any ? U : never;
    ```
    - (...args: infer U) => any 형태처럼 함수 타입인 경우 매개변수 타입을 U로 추론

   - 적용
     ```ts
      type ArgsType<T> = T extends (...args: infer U) => any ? U : never;
      type PromiseReturnType<T> = T extends (...args: any[]) => Promise<infer R> ? R : never;
      
      type UseMutateProps<T extends (...args: any[]) => Promise<any>> = {
        fetchFn: T;
        onSuccess?: (data: PromiseReturnType<T>) => void;
        onError?: (error: unknown) => void;
        onSettled?: (data: PromiseReturnType<T> | undefined, error: unknown) => void;
      };
      
      function useMutate<T extends (...args: any[]) => Promise<any>>({
        fetchFn,
        onSuccess,
        onError,
        onSettled,
      }: UseMutateProps<T>) {
      }
     ```
     
     - 다음 이미지와 같이 미리 정해지지않은 mutate의 파라미터가 deleteTodo에 따라 타입 추론되어 나옴
        <img width="642" alt="image" src="https://github.com/wjdwjdtn92/wanted-pre-onboarding-week4/assets/19286161/283d93f7-70fb-4843-b98e-cb397c43277b">
        
        
- 참고
   - [조건부 타입 + infer - 제이콥님 블로그](https://code-masterjung.tistory.com/123)
        
        
